### PR TITLE
Edit git push/fetch/pull article for clarity.

### DIFF
--- a/understanding-git-push-pull-merge.md
+++ b/understanding-git-push-pull-merge.md
@@ -1,9 +1,18 @@
 # Understanding the `git` Push, Pull, and Fetch Commands
 
-The concepts in this article can help you understand how the `git push`, `git pull`, and `git fetch` commands update your local and remote source control repositories.
+The concepts in this article can help you understand how the `git push`, `git pull`, and `git fetch` commands update your local and remote source control repositories:
 
-- `git push` - sent changes from a local branch to a remote repo
-- `git fetch` - get changes from a remote repo into your tracking branch
-- `git pull` - will get changes from a remote branch into your tracking branch and merge them into a local branch
+- `git push` - Send any changes from your local branch to a remote repository.
+- `git fetch` - Bring any changes in a remote repository branch to your local repository.
+- `git pull` - Runs `git fetch` to gather changes from a remote branch and merges them into a local branch.
 
-Often `git push` and `git pull` are described as equivalent. This isn't entirely correct, since under the hood `git pull` does two things. `git push` takes our current branch, and checks to see whether or not there is a tracking branch for a remote repository connected to it. If so, our changes are taken from our branch and pushed to the remote branch. This is how code is shared with a remote repository, you can think of it as "make the remote branch resemble my local branch". This will fail if the remote branch has diverged from your local branch: if not all the commits in the remote branch are in your local branch. When this happens, your local branch needs to be synchronized with the remote branch with git pull or git fetch and git merge.`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.
+This article also attempts to clarify how `git push` and `git fetch` are logical opposites, while `git pull` combines two tasks.
+
+## How `git push` Updates a Remote Repository
+
+When you run the `git push` command, `git` checks if there is a tracking branch for the default remote repository (you can set multiple remote repositories). If so, `git` sends any local changes as commits to the remote branch. You may think of this process as making the remote branch resemble your local branch.
+
+To update the remote repository, the history between the remote and your local repository must be similar other than any recent changes (those you have made). Updating the remote repository can fail if the commit histories of your local branch and the remote branch are incompatible. For example, your local branch may have more recent commits than the remote, but the commits prior to those must be similar on the two versions of the repository. In this case, you must take steps to update your local branch with the remote branch.
+
+
+`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.

--- a/understanding-git-push-pull-merge.md
+++ b/understanding-git-push-pull-merge.md
@@ -3,8 +3,8 @@
 The concepts in this article can help you understand how the `git push`, `git pull`, and `git fetch` commands update your local and remote source control repositories:
 
 - `git push` - Send any changes from your local branch to a remote repository.
-- `git fetch` - Bring any changes in a remote repository branch to your local repository.
-- `git pull` - Runs `git fetch` to gather changes from a remote branch and merges them into a local branch.
+- `git fetch` - Bring any changes from a remote repository branch to your local repository.
+- `git pull` - Gather changes from a remote branch and merge them into a local branch.
 
 This article also attempts to clarify how `git push` and `git fetch` are logical opposites, while `git pull` combines two tasks.
 
@@ -14,5 +14,12 @@ When you run the `git push` command, `git` checks if there is a tracking branch 
 
 To update the remote repository, the history between the remote and your local repository must be similar other than any recent changes (those you have made). Updating the remote repository can fail if the commit histories of your local branch and the remote branch are incompatible. For example, your local branch may have more recent commits than the remote, but the commits prior to those must be similar on the two versions of the repository. In this case, you must take steps to update your local branch with the remote branch.
 
+## How `git fetch` Updates Your Local Repository
 
-`git fetch` again takes our current branch, and checks to see if there is a tracking branch. If so, it looks for changes in the remote branch, and pulls them into the tracking branch. It does not change your local branch. To do that, you'll need to do `git merge origin/master` (for the "master" branch) to merge those changes into your branch - probably also called "master".`git pull` simply does a `git fetch` followed immediately by `git merge`. This is often what we desire to do, but some people prefer to use git fetch followed by git merge to make sure they understand the changes they are merging into their branch before the merge happens.
+The `git fetch` command checks for any changes in the remote repository for the tracking branch  and updates your local repository branch with those remote changes. The update does not change your working directory or modify your `git` index (the `git` staging area).
+
+To update your working directory with the fetched repository changes use `git merge <REMOTE-NAME>/<BRANCH-NAME>`.
+
+## How `git pull` Updates Your Working Directory
+
+The `git pull` command combines functions by calling `git fetch` and then `git merge`. Because the changes you fetch can sometimes clobber your local working directory contents, you may prefer to fetch and review changes before you merge them.

--- a/understanding-git-push-pull-merge.md
+++ b/understanding-git-push-pull-merge.md
@@ -1,4 +1,6 @@
-## What is the difference between push, pull, and fetch?
+# Understanding the `git` Push, Pull, and Fetch Commands
+
+The concepts in this article can help you understand how the `git push`, `git pull`, and `git fetch` commands update your local and remote source control repositories.
 
 - `git push` - sent changes from a local branch to a remote repo
 - `git fetch` - get changes from a remote repo into your tracking branch

--- a/understanding-git-push-pull-merge.md
+++ b/understanding-git-push-pull-merge.md
@@ -1,4 +1,4 @@
-# Understanding the `git` Push, Pull, and Fetch Commands
+# Understanding the `git` Push, Fetch, and Pull Commands
 
 The concepts in this article can help you understand how the `git push`, `git pull`, and `git fetch` commands update your local and remote source control repositories:
 


### PR DESCRIPTION
This PR addresses an edit of an article about several `git` commands.

## Article Reorganization

I've organized the article as a conceptual one, choosing to forgo several tasks to prioritize what appeared to be the goal of the original content, to clarify why `git pull` is not an equivalent opposite of `git push`, and how a workflow such as `git fetch; git merge`can head off local conflicts.

## Concerns

I have some concern about whether this reorganization is the right way to approach the article (is this really a conceptual article, or could a task reference better address the need?). Additionally, I have some broader concerns about the purpose (and audience) of the article. Lastly, I would hesitate to recommend git workflows in a vacuum, especially given the complexity and sharpness of `git` as a tool. That's probably what most informed my choice to situate this content as conceptual.

Hopefully, this PR provides a sense of how I might communicate about change requests for a technical document. I welcome any review and feedback! 🙏 